### PR TITLE
fix(lib/index): don't handle `<component>` as self-closing tag

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,8 +19,7 @@ var SINGLE_TAGS = [
   // Custom (PostHTML)
   'import',
   'include',
-  'extend',
-  'component'
+  'extend'
 ]
 
 /**


### PR DESCRIPTION
### `Notable Changes`

Don't handle  `<component>` tags as self-closing by default and leave this up the the user instead. It's a custom tag without any particular usage within the PostHTML ecosystem atm and I simply kind of 'reserved' it as a single tag for the future :). This seems to break `.vue` files and `<component>` should therefore be removed from `SINGLE_TAGS` 

### `Type`

- [x] Fix

### `SemVer`

- [x] Fix (:label: Patch)

### `Issues`

- Fixes #18

### `Checklist`

- [x] Lint and unit tests pass with my changes
- [x] I have added tests that prove my fix is effective/works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes are merged and published in downstream modules
