### PR TITLE
Fix rendering double quotes in html attributes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -127,11 +127,10 @@ function attrs (obj) {
   for (var key in obj) {
     if (typeof obj[key] === 'boolean' && obj[key]) {
       attr += ' ' + key
-    } else if (
-      typeof obj[key] === 'string' ||
-      typeof obj[key] === 'number'
-    ) {
+    } else if (typeof obj[key] === 'number') {
       attr += ' ' + key + '="' + obj[key] + '"'
+    } else if (typeof obj[key] === 'string') {
+      attr += ' ' + key + '="' + obj[key].replace(/"/g, '&quot;') + '"'
     }
   }
 

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -103,6 +103,17 @@ describe('PostHTML Render', function () {
 
       expect(render(fixture)).to.eql(expected)
     })
+
+    it('{String} (double quotes)', function () {
+      var fixture = {
+        attrs: {
+          onclick: 'alert("hello world")'
+        }
+      }
+      var expected = '<div onclick="alert(&quot;hello world&quot;)"></div>'
+
+      expect(render(fixture)).to.eql(expected)
+    })
   })
 
   describe('Content', function () {


### PR DESCRIPTION
### `Notable Changes`

Escape double quotes in rendered attributes

#### `Commit Message Summary (CHANGELOG)`

```
Fix rendering double quotes in HTML attributes
```

### `Type`

- [x] Fix

### `SemVer`

- [x] Fix (:label: Patch)

### `Issues`

- Fixes https://github.com/parcel-bundler/parcel/issues/988

### `Checklist`

- [x] Lint and unit tests pass with my changes
- [x] I have added tests that prove my fix is effective/works
