### PR TITLE
feat: new private node property "_withoutClosingTag"

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -204,6 +204,8 @@ function render(tree, options) {
         }
 
         result += html(node.content);
+      } else if (node._withoutClosingTag) {
+        result += '>' + html(node.content);
       } else {
         result += '>' + html(node.content) + '</' + tag + '>';
       }

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -171,6 +171,24 @@ describe('PostHTML Render', () => {
 
       expect(render(fixture)).to.eql(expected);
     });
+
+    it('_withoutClosingTag', () => {
+      const fixture = {
+        content: [
+          {
+            content: [
+              {
+                content: ['Test', {}]
+              }
+            ]
+          }
+        ],
+        _withoutClosingTag: true
+      };
+      const expected = '<div><div><div>Test<div></div></div></div>';
+
+      expect(render(fixture)).to.eql(expected);
+    });
   });
 
   describe('Tree', () => {


### PR DESCRIPTION
### `Notable Changes`

The PR adds support for a private property `_withoutClosingTag`:

```js
// fixture
{
  tag: 'div',
  _withoutClosingTag: true // By default the property won't exist
}
```

will result in

```html
<div>
```

#### `Commit Message Summary (CHANGELOG)`

```
feat: new private node property "_withoutClosingTag"
```

### `Type`

- [x] Feature

### `SemVer`

- [ ] Fix (:label: Patch)
- [x] Feature (:label: Minor)
- [ ] Breaking Change (:label: Major)

### `Issues`

The PR is primarily used to implement https://github.com/posthtml/htmlnano/issues/29, to omit those optional closing tags (without producing invalid HTML). It might also help to handle the case I mentioned in https://github.com/posthtml/posthtml-parser/issues/9#issuecomment-732132189. 

So far `_withoutClosingTag` **should be considered as a private property of `node`** (with `_` prefixed) and **shouldn't be documented**, but we could make it public in the future.

### `Checklist`

- [x] Lint and unit tests pass with my changes
- [x] I have added tests that prove my fix is effective/works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes are merged and published in downstream modules
